### PR TITLE
Determine if there is a next page based off the `next` key

### DIFF
--- a/lib/facebook_ads/edge.rb
+++ b/lib/facebook_ads/edge.rb
@@ -69,7 +69,7 @@ module FacebookAds
         end
 
         self.next_page_cursor = response.dig('paging', 'cursors', 'after')
-        self.has_next_page = !(response['data'].length < fetch_options[:limit])
+        self.has_next_page = !!response.dig('paging', 'next')
       end
     end
 


### PR DESCRIPTION
Please reference the description of the [upstream PR](https://github.com/facebook/facebook-ruby-business-sdk/pull/146).