### PR TITLE
Update facebbok API version to 11.0

### DIFF
--- a/lib/facebook_ads/version.rb
+++ b/lib/facebook_ads/version.rb
@@ -20,5 +20,5 @@
 
 module FacebookAds
   VERSION = '0.10.0.1'
-  API_VERSION = '10.0'
+  API_VERSION = '11.0'
 end


### PR DESCRIPTION
The previous version, 10.0 got deprecated, so I'm manully bumping this to 11.0 as a workaround.
This isn't meant to be a final solution we will need to eventually reconcile back with upstream, or implement our our integrations layer.
But as this is currently blocking customers and sales we wanna make sure to get around it sooner than later