### PR TITLE
Remove the bundler version restriction.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    facebookbusiness (0.9.0.1)
+    facebookbusiness (0.10.0.1)
       concurrent-ruby (~> 1.1)
       countries (~> 3.0)
       faraday (~> 1.0)
@@ -31,7 +31,7 @@ GEM
     i18n_data (0.10.0)
     json (2.3.1)
     method_source (1.0.0)
-    minitest (5.14.1)
+    minitest (5.14.4)
     money (6.13.8)
       i18n (>= 0.6.4, <= 2)
     multipart-post (2.1.1)
@@ -81,12 +81,12 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print (~> 1.8)
-  bundler (~> 1.17)
+  bundler
   byebug (~> 11.0)
   countries (~> 3.0)
   dotenv (~> 2.7)
   facebookbusiness!
-  minitest (~> 5.0)
+  minitest (~> 5.14.2)
   money (~> 6.13)
   pry (~> 0.12)
   pry-coolline (~> 0.2)
@@ -95,4 +95,4 @@ DEPENDENCIES
   rubocop (~> 0.71)
 
 BUNDLED WITH
-   1.17.2
+   2.5.23

--- a/facebookbusiness.gemspec
+++ b/facebookbusiness.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'money', '~> 6.13'
 
   s.add_development_dependency 'awesome_print', '~> 1.8'
-  s.add_development_dependency 'bundler', '~> 1.17'
+  s.add_development_dependency 'bundler'
   s.add_development_dependency 'byebug', '~> 11.0'
   s.add_development_dependency 'dotenv', '~> 2.7'
   s.add_development_dependency 'minitest', '~> 5.14.2'


### PR DESCRIPTION
Resolves four security alerts.

- Critcal
  - https://github.com/clearbit/facebook-ruby-business-sdk/security/dependabot/5
- High
  - https://github.com/clearbit/facebook-ruby-business-sdk/security/dependabot/2
  - https://github.com/clearbit/facebook-ruby-business-sdk/security/dependabot/3
- Moderate
  - https://github.com/clearbit/facebook-ruby-business-sdk/security/dependabot/4